### PR TITLE
flake.nix: refactor nixosSystem function

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -12,11 +12,11 @@
   outputs = { self, nixpkgs, home-manager, ... }@inputs:
     let
       system = "x86_64-linux";
-      nixosSystem = { name, configuration }: nixpkgs.lib.nixosSystem {
+      nixosSystem = { name }: nixpkgs.lib.nixosSystem {
         inherit system;
         specialArgs = { inherit inputs; };
         modules = [
-          configuration
+          ./hosts/${name}/configuration.nix
           inputs.home-manager.nixosModules.home-manager
         ];
       };
@@ -24,33 +24,25 @@
       nixosConfigurations = {
         default = nixosSystem {
           name = "default";
-          configuration = ./hosts/default/configuration.nix;
         };
         desktop = nixosSystem {
           name = "desktop";
-          configuration = ./hosts/desktop/configuration.nix;
         };
         laptop = nixosSystem {
           name = "laptop";
-          configuration = ./hosts/laptop/configuration.nix;
         };
         macbook = nixosSystem {
           name = "macbook";
-          configuration = ./hosts/macbook/configuration.nix;
         };
         home-server = nixosSystem {
           name = "home-server";
-          configuration = ./hosts/home-server/configuration.nix;
         };
         remote-server = nixosSystem {
           name = "remote-server";
-          configuration = ./hosts/remote-server/configuration.nix;
         };
         vm = nixosSystem {
           name = "vm";
-          configuration = ./hosts/vm/configuration.nix;
         };
-	#Add more hosts as needed
       };
     };
 }


### PR DESCRIPTION
Since your system names are the same as the directory names you can simplify your `nixosSystem`.